### PR TITLE
remove deps

### DIFF
--- a/lua/forkyou/init.lua
+++ b/lua/forkyou/init.lua
@@ -1,5 +1,3 @@
-local json = require("dkjson")
-
 local M = {}
 
 local function hex_to_bytes(hex)
@@ -117,7 +115,8 @@ local function sync()
     return
   end
 
-  local body = json.encode(activities, { indent = false }, false)
+  local body = vim.json.encode(activities)
+
   activities = {}
 
   local hmac_hex = get_hmac_signature(body, raw_key)


### PR DESCRIPTION
## Changes made:
- replace openssl lua dep with vim system cmd
- replace dkjson dep with vim's internal json encoding api

Note: Users would require openssl and xxd installed on their system to be able to generate the hmac signature. The dependency moved from a plugin level to a system level which they'd mostly have on their systems